### PR TITLE
Make vscode configs use `ruff` formatter

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -10,7 +10,8 @@
                         "extensions": [
                                 "ms-python.python",
                                 "ms-python.vscode-pylance",
-                                "ms-python.vscode-python-envs"
+                                "ms-python.vscode-python-envs",
+                                "charliermarsh.ruff"
                         ]
                 }
         },

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,5 +3,14 @@
         "tests"
     ],
     "python.testing.unittestEnabled": false,
-    "python.testing.pytestEnabled": true
+    "python.testing.pytestEnabled": true,
+    "[python]": {
+        "editor.formatOnSave": true,
+        "editor.codeActionsOnSave": {
+            "source.fixAll": "explicit",
+            "source.unusedImports": "explicit",
+            "source.organizeImports": "explicit"
+        },
+        "editor.defaultFormatter": "charliermarsh.ruff"
+    }
 }


### PR DESCRIPTION
Adds `python` editor configs which will do the `ruff` format/checks automatically on save. This should reduce the annoyance of needing to keep doing `ruff format` before committing