### PR TITLE
Bug fix: don't add an empty user prompt in multi-tool use scenarios

### DIFF
--- a/llm_github_models.py
+++ b/llm_github_models.py
@@ -245,7 +245,7 @@ def build_messages(
                 for attachment in prev_response.attachments:
                     attachment_message.append(attachment_as_content_item(attachment))
                 messages.append(UserMessage(attachment_message))
-            else:
+            elif prev_response.prompt.prompt:
                 messages.append(UserMessage(prev_response.prompt.prompt))
 
             # Add any tool results from the previous prompt

--- a/tests/test_tool_support.py
+++ b/tests/test_tool_support.py
@@ -150,3 +150,39 @@ async def test_async_uses_tools(stream):
     # Sometimes it likes to add commas to the output number
     response_text = (await responses[1].text()).replace(",", "")
     assert "7303652730" in response_text
+
+
+def test_multi_tool_use():
+    model = get_model("github/gpt-4o-mini")
+
+    # Create a prompt with a tool
+    def multiply(x: int, y: int) -> int:
+        """Multiply two numbers."""
+        return x * y
+
+    def add(x: int, y: int) -> int:
+        """Add two numbers."""
+        return x + y
+
+    chain = model.chain(
+        "What is (34234 * 213345) + (45345 * 324456)?",
+        tools=[multiply, add],  # type: ignore
+    ).responses()
+
+    tool_calls = next(chain).tool_calls()
+    assert tool_calls is not None
+    assert len(tool_calls) == 2
+    assert tool_calls[0].name == "multiply"
+    assert tool_calls[0].arguments == {"x": 34234, "y": 213345}
+
+    assert tool_calls[1].name == "multiply"
+    assert tool_calls[1].arguments == {"x": 45345, "y": 324456}
+
+    tool_calls = next(chain).tool_calls()
+    assert len(tool_calls) == 1
+    assert tool_calls[0].name == "add"
+    assert tool_calls[0].arguments == {"x": 7303652730, "y": 14712457320}
+
+    # Sometimes it likes to add commas to the output number
+    response_text = next(chain).text().replace(",", "")
+    assert "22016110050" in response_text


### PR DESCRIPTION
The API expects `tool_call` messages to be immediately followed by their results.

However, there's a bug in the previous message rebuilding logic that will accidentally insert an empty user prompt message which breaks this rule and causes an error like 

```
Error: (None) An assistant message with 'tool_calls' must be followed by tool messages responding to each 'tool_call_id'. The following tool_call_ids did not have response messages: call_EsQHgm5PGNvnvuVVh3tvvaEr
Code: None
Message: An assistant message with 'tool_calls' must be followed by tool messages responding to each 'tool_call_id'. The following tool_call_ids did not have response messages: call_EsQHgm5PGNvnvuVVh3tvvaEr
```

This bug only appears if the for cases where we're doing multiple rounds of tool calls and prompts which is why it was missed originally. Added a test to handle multiple tool calls and confirmed that the bug repro'd before and is gone after.