### PR TITLE
Remove the `can_stream` option - the models in the list actually can stream

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,66 +62,66 @@ The overall atmosphere of the image exudes tranquility, with the pelicans seemin
 
 ### Chat Models
 
-| Model Name | Streaming | Schemas | Tools | Input Modalities | Output Modalities |
-|------------|-----------|---------|-------|------------------|-------------------|
-| AI21-Jamba-1.5-Large | ✅ | ❌ | ❌ | text | text |
-| AI21-Jamba-1.5-Mini | ✅ | ❌ | ❌ | text | text |
-| Codestral-2501 | ✅ | ❌ | ✅ | text | text |
-| Cohere-command-r | ✅ | ❌ | ✅ | text | text |
-| Cohere-command-r-08-2024 | ✅ | ❌ | ✅ | text | text |
-| Cohere-command-r-plus | ✅ | ❌ | ✅ | text | text |
-| Cohere-command-r-plus-08-2024 | ✅ | ❌ | ✅ | text | text |
-| DeepSeek-R1 | ✅ | ❌ | ❌ | text | text |
-| DeepSeek-V3 | ✅ | ❌ | ❌ | text | text |
-| DeepSeek-V3-0324 | ✅ | ❌ | ❌ | text | text |
-| Llama-3.2-11B-Vision-Instruct | ✅ | ❌ | ❌ | text, image, audio | text |
-| Llama-3.2-90B-Vision-Instruct | ✅ | ❌ | ❌ | text, image, audio | text |
-| Llama-3.3-70B-Instruct | ✅ | ❌ | ❌ | text | text |
-| Llama-4-Maverick-17B-128E-Instruct-FP8 | ✅ | ❌ | ❌ | text, image | text |
-| Llama-4-Scout-17B-16E-Instruct | ✅ | ❌ | ❌ | text, image | text |
-| MAI-DS-R1 | ✅ | ❌ | ❌ | text | text |
-| Meta-Llama-3-70B-Instruct | ✅ | ❌ | ❌ | text | text |
-| Meta-Llama-3-8B-Instruct | ✅ | ❌ | ❌ | text | text |
-| Meta-Llama-3.1-405B-Instruct | ✅ | ❌ | ❌ | text | text |
-| Meta-Llama-3.1-70B-Instruct | ✅ | ❌ | ❌ | text | text |
-| Meta-Llama-3.1-8B-Instruct | ✅ | ❌ | ❌ | text | text |
-| Ministral-3B | ✅ | ❌ | ✅ | text | text |
-| Mistral-Large-2411 | ✅ | ❌ | ✅ | text | text |
-| Mistral-Nemo | ✅ | ❌ | ✅ | text | text |
-| Mistral-large | ✅ | ❌ | ✅ | text | text |
-| Mistral-large-2407 | ✅ | ❌ | ✅ | text | text |
-| Mistral-small | ✅ | ❌ | ✅ | text | text |
-| Phi-3-medium-128k-instruct | ✅ | ❌ | ❌ | text | text |
-| Phi-3-medium-4k-instruct | ✅ | ❌ | ❌ | text | text |
-| Phi-3-mini-128k-instruct | ✅ | ❌ | ❌ | text | text |
-| Phi-3-mini-4k-instruct | ✅ | ❌ | ❌ | text | text |
-| Phi-3-small-128k-instruct | ✅ | ❌ | ❌ | text | text |
-| Phi-3-small-8k-instruct | ✅ | ❌ | ❌ | text | text |
-| Phi-3.5-MoE-instruct | ✅ | ❌ | ❌ | text | text |
-| Phi-3.5-mini-instruct | ✅ | ❌ | ❌ | text | text |
-| Phi-3.5-vision-instruct | ✅ | ❌ | ❌ | text, image | text |
-| Phi-4 | ✅ | ❌ | ❌ | text | text |
-| Phi-4-mini-instruct | ✅ | ❌ | ❌ | text | text |
-| Phi-4-mini-reasoning | ✅ | ❌ | ❌ | text | text |
-| Phi-4-multimodal-instruct | ✅ | ❌ | ❌ | audio, image, text | text |
-| Phi-4-reasoning | ✅ | ❌ | ❌ | text | text |
-| cohere-command-a | ✅ | ❌ | ✅ | text | text |
-| gpt-4.1 | ✅ | ✅ | ✅ | text, image | text |
-| gpt-4.1-mini | ✅ | ✅ | ✅ | text, image | text |
-| gpt-4.1-nano | ✅ | ✅ | ✅ | text, image | text |
-| gpt-4o | ✅ | ✅ | ✅ | text, image, audio | text |
-| gpt-4o-mini | ✅ | ✅ | ✅ | text, image, audio | text |
-| grok-3 | ✅ | ❌ | ✅ | text | text |
-| grok-3-mini | ✅ | ❌ | ✅ | text | text |
-| jais-30b-chat | ✅ | ❌ | ❌ | text | text |
-| mistral-medium-2505 | ✅ | ❌ | ✅ | text, image | text |
-| mistral-small-2503 | ✅ | ❌ | ✅ | text, image | text |
-| o1 | ❌ | ✅ | ✅ | text, image | text |
-| o1-mini | ❌ | ❌ | ❌ | text | text |
-| o1-preview | ❌ | ❌ | ❌ | text | text |
-| o3 | ✅ | ❌ | ✅ | text, image | text |
-| o3-mini | ❌ | ✅ | ✅ | text | text |
-| o4-mini | ✅ | ❌ | ✅ | text, image | text |
+| Model Name | Schemas | Tools | Input Modalities | Output Modalities |
+|------------|---------|-------|------------------|-------------------|
+| AI21-Jamba-1.5-Large | ❌ | ❌ | text | text |
+| AI21-Jamba-1.5-Mini | ❌ | ❌ | text | text |
+| Codestral-2501 | ❌ | ✅ | text | text |
+| Cohere-command-r | ❌ | ✅ | text | text |
+| Cohere-command-r-08-2024 | ❌ | ✅ | text | text |
+| Cohere-command-r-plus | ❌ | ✅ | text | text |
+| Cohere-command-r-plus-08-2024 | ❌ | ✅ | text | text |
+| DeepSeek-R1 | ❌ | ❌ | text | text |
+| DeepSeek-V3 | ❌ | ❌ | text | text |
+| DeepSeek-V3-0324 | ❌ | ❌ | text | text |
+| Llama-3.2-11B-Vision-Instruct | ❌ | ❌ | text, image, audio | text |
+| Llama-3.2-90B-Vision-Instruct | ❌ | ❌ | text, image, audio | text |
+| Llama-3.3-70B-Instruct | ❌ | ❌ | text | text |
+| Llama-4-Maverick-17B-128E-Instruct-FP8 | ❌ | ❌ | text, image | text |
+| Llama-4-Scout-17B-16E-Instruct | ❌ | ❌ | text, image | text |
+| MAI-DS-R1 | ❌ | ❌ | text | text |
+| Meta-Llama-3-70B-Instruct | ❌ | ❌ | text | text |
+| Meta-Llama-3-8B-Instruct | ❌ | ❌ | text | text |
+| Meta-Llama-3.1-405B-Instruct | ❌ | ❌ | text | text |
+| Meta-Llama-3.1-70B-Instruct | ❌ | ❌ | text | text |
+| Meta-Llama-3.1-8B-Instruct | ❌ | ❌ | text | text |
+| Ministral-3B | ❌ | ✅ | text | text |
+| Mistral-Large-2411 | ❌ | ✅ | text | text |
+| Mistral-Nemo | ❌ | ✅ | text | text |
+| Mistral-large | ❌ | ✅ | text | text |
+| Mistral-large-2407 | ❌ | ✅ | text | text |
+| Mistral-small | ❌ | ✅ | text | text |
+| Phi-3-medium-128k-instruct | ❌ | ❌ | text | text |
+| Phi-3-medium-4k-instruct | ❌ | ❌ | text | text |
+| Phi-3-mini-128k-instruct | ❌ | ❌ | text | text |
+| Phi-3-mini-4k-instruct | ❌ | ❌ | text | text |
+| Phi-3-small-128k-instruct | ❌ | ❌ | text | text |
+| Phi-3-small-8k-instruct | ❌ | ❌ | text | text |
+| Phi-3.5-MoE-instruct | ❌ | ❌ | text | text |
+| Phi-3.5-mini-instruct | ❌ | ❌ | text | text |
+| Phi-3.5-vision-instruct | ❌ | ❌ | text, image | text |
+| Phi-4 | ❌ | ❌ | text | text |
+| Phi-4-mini-instruct | ❌ | ❌ | text | text |
+| Phi-4-mini-reasoning | ❌ | ❌ | text | text |
+| Phi-4-multimodal-instruct | ❌ | ❌ | audio, image, text | text |
+| Phi-4-reasoning | ❌ | ❌ | text | text |
+| cohere-command-a | ❌ | ✅ | text | text |
+| gpt-4.1 | ✅ | ✅ | text, image | text |
+| gpt-4.1-mini | ✅ | ✅ | text, image | text |
+| gpt-4.1-nano | ✅ | ✅ | text, image | text |
+| gpt-4o | ✅ | ✅ | text, image, audio | text |
+| gpt-4o-mini | ✅ | ✅ | text, image, audio | text |
+| grok-3 | ❌ | ✅ | text | text |
+| grok-3-mini | ❌ | ✅ | text | text |
+| jais-30b-chat | ❌ | ❌ | text | text |
+| mistral-medium-2505 | ❌ | ✅ | text, image | text |
+| mistral-small-2503 | ❌ | ✅ | text, image | text |
+| o1 | ✅ | ✅ | text, image | text |
+| o1-mini | ❌ | ❌ | text | text |
+| o1-preview | ❌ | ❌ | text | text |
+| o3 | ❌ | ✅ | text, image | text |
+| o3-mini | ✅ | ✅ | text | text |
+| o4-mini | ❌ | ✅ | text, image | text |
 
 ### AI21 Jamba 1.5 Large
 

--- a/llm_github_models.py
+++ b/llm_github_models.py
@@ -35,96 +35,74 @@ from llm.models import (
     Attachment,
     Conversation,
     EmbeddingModel,
+    Model,
     Prompt,
     Response,
+    ToolCall,
 )
 from pydantic import BaseModel
 
 INFERENCE_ENDPOINT = "https://models.inference.ai.azure.com"
 
 CHAT_MODELS = [
-    ("AI21-Jamba-1.5-Large", True, False, False, False, ["text"], ["text"]),
-    ("AI21-Jamba-1.5-Mini", True, False, False, False, ["text"], ["text"]),
-    ("Codestral-2501", True, False, False, True, ["text"], ["text"]),
-    ("Cohere-command-r", True, False, False, True, ["text"], ["text"]),
-    ("Cohere-command-r-08-2024", True, False, False, True, ["text"], ["text"]),
-    ("Cohere-command-r-plus", True, False, False, True, ["text"], ["text"]),
-    ("Cohere-command-r-plus-08-2024", True, False, False, True, ["text"], ["text"]),
-    ("DeepSeek-R1", True, False, False, False, ["text"], ["text"]),
-    ("DeepSeek-V3", True, False, False, False, ["text"], ["text"]),
-    ("DeepSeek-V3-0324", True, False, False, False, ["text"], ["text"]),
-    (
-        "Llama-3.2-11B-Vision-Instruct",
-        True,
-        False,
-        False,
-        False,
-        ["text", "image", "audio"],
-        ["text"],
-    ),
-    (
-        "Llama-3.2-90B-Vision-Instruct",
-        True,
-        False,
-        False,
-        False,
-        ["text", "image", "audio"],
-        ["text"],
-    ),
-    ("Llama-3.3-70B-Instruct", True, False, False, False, ["text"], ["text"]),
-    (
-        "Llama-4-Maverick-17B-128E-Instruct-FP8",
-        True,
-        False,
-        False,
-        False,
-        ["text", "image"],
-        ["text"],
-    ),
-    ("Llama-4-Scout-17B-16E-Instruct", True, False, False, False, ["text", "image"], ["text"]),
-    ("MAI-DS-R1", True, False, False, False, ["text"], ["text"]),
-    ("Meta-Llama-3-70B-Instruct", True, False, False, False, ["text"], ["text"]),
-    ("Meta-Llama-3-8B-Instruct", True, False, False, False, ["text"], ["text"]),
-    ("Meta-Llama-3.1-405B-Instruct", True, False, False, False, ["text"], ["text"]),
-    ("Meta-Llama-3.1-70B-Instruct", True, False, False, False, ["text"], ["text"]),
-    ("Meta-Llama-3.1-8B-Instruct", True, False, False, False, ["text"], ["text"]),
-    ("Ministral-3B", True, False, False, True, ["text"], ["text"]),
-    ("Mistral-Large-2411", True, False, False, True, ["text"], ["text"]),
-    ("Mistral-Nemo", True, False, False, True, ["text"], ["text"]),
-    ("Mistral-large", True, False, False, True, ["text"], ["text"]),
-    ("Mistral-large-2407", True, False, False, True, ["text"], ["text"]),
-    ("Mistral-small", True, False, False, True, ["text"], ["text"]),
-    ("Phi-3-medium-128k-instruct", True, False, False, False, ["text"], ["text"]),
-    ("Phi-3-medium-4k-instruct", True, False, False, False, ["text"], ["text"]),
-    ("Phi-3-mini-128k-instruct", True, False, False, False, ["text"], ["text"]),
-    ("Phi-3-mini-4k-instruct", True, False, False, False, ["text"], ["text"]),
-    ("Phi-3-small-128k-instruct", True, False, False, False, ["text"], ["text"]),
-    ("Phi-3-small-8k-instruct", True, False, False, False, ["text"], ["text"]),
-    ("Phi-3.5-MoE-instruct", True, False, False, False, ["text"], ["text"]),
-    ("Phi-3.5-mini-instruct", True, False, False, False, ["text"], ["text"]),
-    ("Phi-3.5-vision-instruct", True, False, False, False, ["text", "image"], None),
-    ("Phi-4", True, False, False, False, ["text"], ["text"]),
-    ("Phi-4-mini-instruct", True, False, False, False, ["text"], ["text"]),
-    ("Phi-4-mini-reasoning", True, False, False, False, ["text"], ["text"]),
-    ("Phi-4-multimodal-instruct", True, False, False, False, ["audio", "image", "text"], ["text"]),
-    ("Phi-4-reasoning", True, False, False, False, ["text"], ["text"]),
-    ("cohere-command-a", True, False, False, True, ["text"], ["text"]),
-    ("gpt-4.1", True, True, True, True, ["text", "image"], ["text"]),
-    ("gpt-4.1-mini", True, True, True, True, ["text", "image"], ["text"]),
-    ("gpt-4.1-nano", True, True, True, True, ["text", "image"], ["text"]),
-    ("gpt-4o", True, True, True, True, ["text", "image", "audio"], ["text"]),
-    ("gpt-4o-mini", True, True, True, True, ["text", "image", "audio"], ["text"]),
-    ("grok-3", True, False, False, True, ["text"], ["text"]),
-    ("grok-3-mini", True, False, False, True, ["text"], ["text"]),
-    ("jais-30b-chat", True, False, False, False, ["text"], ["text"]),
-    ("mistral-medium-2505", True, False, False, True, ["text", "image"], ["text"]),
-    ("mistral-small-2503", True, False, False, True, ["text", "image"], ["text"]),
-    ("o1", False, True, False, True, ["text", "image"], ["text"]),
-    ("o1-mini", False, False, False, False, ["text"], ["text"]),
-    ("o1-preview", False, False, False, False, ["text"], ["text"]),
-    ("o3", True, False, True, True, ["text", "image"], ["text"]),
-    ("o3-mini", False, True, False, True, ["text"], ["text"]),
-    ("o4-mini", True, False, True, True, ["text", "image"], ["text"]),
+    ("AI21-Jamba-1.5-Large", False, False, False, ["text"], ["text"]),
+    ("AI21-Jamba-1.5-Mini", False, False, False, ["text"], ["text"]),
+    ("Codestral-2501", False, False, True, ["text"], ["text"]),
+    ("Cohere-command-r", False, False, True, ["text"], ["text"]),
+    ("Cohere-command-r-08-2024", False, False, True, ["text"], ["text"]),
+    ("Cohere-command-r-plus", False, False, True, ["text"], ["text"]),
+    ("Cohere-command-r-plus-08-2024", False, False, True, ["text"], ["text"]),
+    ("DeepSeek-R1", False, False, False, ["text"], ["text"]),
+    ("DeepSeek-V3", False, False, False, ["text"], ["text"]),
+    ("DeepSeek-V3-0324", False, False, False, ["text"], ["text"]),
+    ("Llama-3.2-11B-Vision-Instruct", False, False, False, ["text", "image", "audio"], ["text"]),
+    ("Llama-3.2-90B-Vision-Instruct", False, False, False, ["text", "image", "audio"], ["text"]),
+    ("Llama-3.3-70B-Instruct", False, False, False, ["text"], ["text"]),
+    ("Llama-4-Maverick-17B-128E-Instruct-FP8", False, False, False, ["text", "image"], ["text"]),
+    ("Llama-4-Scout-17B-16E-Instruct", False, False, False, ["text", "image"], ["text"]),
+    ("MAI-DS-R1", False, False, False, ["text"], ["text"]),
+    ("Meta-Llama-3-70B-Instruct", False, False, False, ["text"], ["text"]),
+    ("Meta-Llama-3-8B-Instruct", False, False, False, ["text"], ["text"]),
+    ("Meta-Llama-3.1-405B-Instruct", False, False, False, ["text"], ["text"]),
+    ("Meta-Llama-3.1-70B-Instruct", False, False, False, ["text"], ["text"]),
+    ("Meta-Llama-3.1-8B-Instruct", False, False, False, ["text"], ["text"]),
+    ("Ministral-3B", False, False, True, ["text"], ["text"]),
+    ("Mistral-Large-2411", False, False, True, ["text"], ["text"]),
+    ("Mistral-Nemo", False, False, True, ["text"], ["text"]),
+    ("Mistral-large", False, False, True, ["text"], ["text"]),
+    ("Mistral-large-2407", False, False, True, ["text"], ["text"]),
+    ("Mistral-small", False, False, True, ["text"], ["text"]),
+    ("Phi-3-medium-128k-instruct", False, False, False, ["text"], ["text"]),
+    ("Phi-3-medium-4k-instruct", False, False, False, ["text"], ["text"]),
+    ("Phi-3-mini-128k-instruct", False, False, False, ["text"], ["text"]),
+    ("Phi-3-mini-4k-instruct", False, False, False, ["text"], ["text"]),
+    ("Phi-3-small-128k-instruct", False, False, False, ["text"], ["text"]),
+    ("Phi-3-small-8k-instruct", False, False, False, ["text"], ["text"]),
+    ("Phi-3.5-MoE-instruct", False, False, False, ["text"], ["text"]),
+    ("Phi-3.5-mini-instruct", False, False, False, ["text"], ["text"]),
+    ("Phi-3.5-vision-instruct", False, False, False, ["text", "image"], None),
+    ("Phi-4", False, False, False, ["text"], ["text"]),
+    ("Phi-4-mini-instruct", False, False, False, ["text"], ["text"]),
+    ("Phi-4-mini-reasoning", False, False, False, ["text"], ["text"]),
+    ("Phi-4-multimodal-instruct", False, False, False, ["audio", "image", "text"], ["text"]),
+    ("Phi-4-reasoning", False, False, False, ["text"], ["text"]),
+    ("cohere-command-a", False, False, True, ["text"], ["text"]),
+    ("gpt-4.1", True, True, True, ["text", "image"], ["text"]),
+    ("gpt-4.1-mini", True, True, True, ["text", "image"], ["text"]),
+    ("gpt-4.1-nano", True, True, True, ["text", "image"], ["text"]),
+    ("gpt-4o", True, True, True, ["text", "image", "audio"], ["text"]),
+    ("gpt-4o-mini", True, True, True, ["text", "image", "audio"], ["text"]),
+    ("grok-3", False, False, True, ["text"], ["text"]),
+    ("grok-3-mini", False, False, True, ["text"], ["text"]),
+    ("jais-30b-chat", False, False, False, ["text"], ["text"]),
+    ("mistral-medium-2505", False, False, True, ["text", "image"], ["text"]),
+    ("mistral-small-2503", False, False, True, ["text", "image"], ["text"]),
+    ("o1", True, False, True, ["text", "image"], ["text"]),
+    ("o1-mini", False, False, False, ["text"], ["text"]),
+    ("o1-preview", False, False, False, ["text"], ["text"]),
+    ("o3", False, True, True, ["text", "image"], ["text"]),
+    ("o3-mini", True, False, True, ["text"], ["text"]),
+    ("o4-mini", False, True, True, ["text", "image"], ["text"]),
 ]
 
 EMBEDDING_MODELS = [
@@ -141,7 +119,6 @@ def register_models(register):
     # TODO: Dynamically fetch this list
     for (
         model_id,
-        can_stream,
         supports_schema,
         requires_usage_stream_option,
         supports_tools,
@@ -151,7 +128,6 @@ def register_models(register):
         register(
             GitHubModels(
                 model_id,
-                can_stream=can_stream,
                 supports_schema=supports_schema,
                 requires_usage_stream_option=requires_usage_stream_option,
                 supports_tools=supports_tools,
@@ -160,7 +136,6 @@ def register_models(register):
             ),
             GitHubAsyncModels(
                 model_id,
-                can_stream=can_stream,
                 supports_schema=supports_schema,
                 requires_usage_stream_option=requires_usage_stream_option,
                 supports_tools=supports_tools,
@@ -344,7 +319,7 @@ def add_tool_calls(
             arguments = {"error": "Invalid JSON in arguments"}
 
         response.add_tool_call(
-            llm.ToolCall(
+            ToolCall(
                 tool_call_id=tool_call.id,
                 name=tool_call.function.name,
                 arguments=arguments,
@@ -355,11 +330,11 @@ def add_tool_calls(
 class _Shared:
     needs_key = "github"
     key_env_var = "GITHUB_MODELS_KEY"
+    can_stream = True
 
     def __init__(
         self,
         model_id: str,
-        can_stream: bool = True,
         supports_schema: bool = False,
         requires_usage_stream_option: bool = True,
         supports_tools: bool = False,
@@ -368,7 +343,6 @@ class _Shared:
     ):
         self.model_id = f"github/{model_id}"
         self.model_name = model_id
-        self.can_stream = can_stream
         self.supports_schema = supports_schema
         self.supports_tools = supports_tools
         self.attachment_types = set()
@@ -411,7 +385,7 @@ class _Shared:
         ]
 
 
-class GitHubModels(_Shared, llm.Model):
+class GitHubModels(_Shared, Model):
     def execute(
         self,
         prompt: Prompt,
@@ -475,6 +449,7 @@ class GitHubModels(_Shared, llm.Model):
 
                 response.response_json = None  # TODO
             else:
+                raise ValueError("Tried to use non-streaming")
                 completion = client.complete(
                     messages=messages,
                     stream=False,
@@ -557,6 +532,7 @@ class GitHubAsyncModels(_Shared, AsyncModel):
 
                 response.response_json = None  # TODO
             else:
+                raise "NOOOOO"
                 completion = await client.complete(
                     messages=messages,
                     stream=False,

--- a/tools/models.fragment.md
+++ b/tools/models.fragment.md
@@ -2,66 +2,66 @@
 
 ### Chat Models
 
-| Model Name | Streaming | Schemas | Tools | Input Modalities | Output Modalities |
-|------------|-----------|---------|-------|------------------|-------------------|
-| AI21-Jamba-1.5-Large | ✅ | ❌ | ❌ | text | text |
-| AI21-Jamba-1.5-Mini | ✅ | ❌ | ❌ | text | text |
-| Codestral-2501 | ✅ | ❌ | ✅ | text | text |
-| Cohere-command-r | ✅ | ❌ | ✅ | text | text |
-| Cohere-command-r-08-2024 | ✅ | ❌ | ✅ | text | text |
-| Cohere-command-r-plus | ✅ | ❌ | ✅ | text | text |
-| Cohere-command-r-plus-08-2024 | ✅ | ❌ | ✅ | text | text |
-| DeepSeek-R1 | ✅ | ❌ | ❌ | text | text |
-| DeepSeek-V3 | ✅ | ❌ | ❌ | text | text |
-| DeepSeek-V3-0324 | ✅ | ❌ | ❌ | text | text |
-| Llama-3.2-11B-Vision-Instruct | ✅ | ❌ | ❌ | text, image, audio | text |
-| Llama-3.2-90B-Vision-Instruct | ✅ | ❌ | ❌ | text, image, audio | text |
-| Llama-3.3-70B-Instruct | ✅ | ❌ | ❌ | text | text |
-| Llama-4-Maverick-17B-128E-Instruct-FP8 | ✅ | ❌ | ❌ | text, image | text |
-| Llama-4-Scout-17B-16E-Instruct | ✅ | ❌ | ❌ | text, image | text |
-| MAI-DS-R1 | ✅ | ❌ | ❌ | text | text |
-| Meta-Llama-3-70B-Instruct | ✅ | ❌ | ❌ | text | text |
-| Meta-Llama-3-8B-Instruct | ✅ | ❌ | ❌ | text | text |
-| Meta-Llama-3.1-405B-Instruct | ✅ | ❌ | ❌ | text | text |
-| Meta-Llama-3.1-70B-Instruct | ✅ | ❌ | ❌ | text | text |
-| Meta-Llama-3.1-8B-Instruct | ✅ | ❌ | ❌ | text | text |
-| Ministral-3B | ✅ | ❌ | ✅ | text | text |
-| Mistral-Large-2411 | ✅ | ❌ | ✅ | text | text |
-| Mistral-Nemo | ✅ | ❌ | ✅ | text | text |
-| Mistral-large | ✅ | ❌ | ✅ | text | text |
-| Mistral-large-2407 | ✅ | ❌ | ✅ | text | text |
-| Mistral-small | ✅ | ❌ | ✅ | text | text |
-| Phi-3-medium-128k-instruct | ✅ | ❌ | ❌ | text | text |
-| Phi-3-medium-4k-instruct | ✅ | ❌ | ❌ | text | text |
-| Phi-3-mini-128k-instruct | ✅ | ❌ | ❌ | text | text |
-| Phi-3-mini-4k-instruct | ✅ | ❌ | ❌ | text | text |
-| Phi-3-small-128k-instruct | ✅ | ❌ | ❌ | text | text |
-| Phi-3-small-8k-instruct | ✅ | ❌ | ❌ | text | text |
-| Phi-3.5-MoE-instruct | ✅ | ❌ | ❌ | text | text |
-| Phi-3.5-mini-instruct | ✅ | ❌ | ❌ | text | text |
-| Phi-3.5-vision-instruct | ✅ | ❌ | ❌ | text, image | text |
-| Phi-4 | ✅ | ❌ | ❌ | text | text |
-| Phi-4-mini-instruct | ✅ | ❌ | ❌ | text | text |
-| Phi-4-mini-reasoning | ✅ | ❌ | ❌ | text | text |
-| Phi-4-multimodal-instruct | ✅ | ❌ | ❌ | audio, image, text | text |
-| Phi-4-reasoning | ✅ | ❌ | ❌ | text | text |
-| cohere-command-a | ✅ | ❌ | ✅ | text | text |
-| gpt-4.1 | ✅ | ✅ | ✅ | text, image | text |
-| gpt-4.1-mini | ✅ | ✅ | ✅ | text, image | text |
-| gpt-4.1-nano | ✅ | ✅ | ✅ | text, image | text |
-| gpt-4o | ✅ | ✅ | ✅ | text, image, audio | text |
-| gpt-4o-mini | ✅ | ✅ | ✅ | text, image, audio | text |
-| grok-3 | ✅ | ❌ | ✅ | text | text |
-| grok-3-mini | ✅ | ❌ | ✅ | text | text |
-| jais-30b-chat | ✅ | ❌ | ❌ | text | text |
-| mistral-medium-2505 | ✅ | ❌ | ✅ | text, image | text |
-| mistral-small-2503 | ✅ | ❌ | ✅ | text, image | text |
-| o1 | ❌ | ✅ | ✅ | text, image | text |
-| o1-mini | ❌ | ❌ | ❌ | text | text |
-| o1-preview | ❌ | ❌ | ❌ | text | text |
-| o3 | ✅ | ❌ | ✅ | text, image | text |
-| o3-mini | ❌ | ✅ | ✅ | text | text |
-| o4-mini | ✅ | ❌ | ✅ | text, image | text |
+| Model Name | Schemas | Tools | Input Modalities | Output Modalities |
+|------------|---------|-------|------------------|-------------------|
+| AI21-Jamba-1.5-Large | ❌ | ❌ | text | text |
+| AI21-Jamba-1.5-Mini | ❌ | ❌ | text | text |
+| Codestral-2501 | ❌ | ✅ | text | text |
+| Cohere-command-r | ❌ | ✅ | text | text |
+| Cohere-command-r-08-2024 | ❌ | ✅ | text | text |
+| Cohere-command-r-plus | ❌ | ✅ | text | text |
+| Cohere-command-r-plus-08-2024 | ❌ | ✅ | text | text |
+| DeepSeek-R1 | ❌ | ❌ | text | text |
+| DeepSeek-V3 | ❌ | ❌ | text | text |
+| DeepSeek-V3-0324 | ❌ | ❌ | text | text |
+| Llama-3.2-11B-Vision-Instruct | ❌ | ❌ | text, image, audio | text |
+| Llama-3.2-90B-Vision-Instruct | ❌ | ❌ | text, image, audio | text |
+| Llama-3.3-70B-Instruct | ❌ | ❌ | text | text |
+| Llama-4-Maverick-17B-128E-Instruct-FP8 | ❌ | ❌ | text, image | text |
+| Llama-4-Scout-17B-16E-Instruct | ❌ | ❌ | text, image | text |
+| MAI-DS-R1 | ❌ | ❌ | text | text |
+| Meta-Llama-3-70B-Instruct | ❌ | ❌ | text | text |
+| Meta-Llama-3-8B-Instruct | ❌ | ❌ | text | text |
+| Meta-Llama-3.1-405B-Instruct | ❌ | ❌ | text | text |
+| Meta-Llama-3.1-70B-Instruct | ❌ | ❌ | text | text |
+| Meta-Llama-3.1-8B-Instruct | ❌ | ❌ | text | text |
+| Ministral-3B | ❌ | ✅ | text | text |
+| Mistral-Large-2411 | ❌ | ✅ | text | text |
+| Mistral-Nemo | ❌ | ✅ | text | text |
+| Mistral-large | ❌ | ✅ | text | text |
+| Mistral-large-2407 | ❌ | ✅ | text | text |
+| Mistral-small | ❌ | ✅ | text | text |
+| Phi-3-medium-128k-instruct | ❌ | ❌ | text | text |
+| Phi-3-medium-4k-instruct | ❌ | ❌ | text | text |
+| Phi-3-mini-128k-instruct | ❌ | ❌ | text | text |
+| Phi-3-mini-4k-instruct | ❌ | ❌ | text | text |
+| Phi-3-small-128k-instruct | ❌ | ❌ | text | text |
+| Phi-3-small-8k-instruct | ❌ | ❌ | text | text |
+| Phi-3.5-MoE-instruct | ❌ | ❌ | text | text |
+| Phi-3.5-mini-instruct | ❌ | ❌ | text | text |
+| Phi-3.5-vision-instruct | ❌ | ❌ | text, image | text |
+| Phi-4 | ❌ | ❌ | text | text |
+| Phi-4-mini-instruct | ❌ | ❌ | text | text |
+| Phi-4-mini-reasoning | ❌ | ❌ | text | text |
+| Phi-4-multimodal-instruct | ❌ | ❌ | audio, image, text | text |
+| Phi-4-reasoning | ❌ | ❌ | text | text |
+| cohere-command-a | ❌ | ✅ | text | text |
+| gpt-4.1 | ✅ | ✅ | text, image | text |
+| gpt-4.1-mini | ✅ | ✅ | text, image | text |
+| gpt-4.1-nano | ✅ | ✅ | text, image | text |
+| gpt-4o | ✅ | ✅ | text, image, audio | text |
+| gpt-4o-mini | ✅ | ✅ | text, image, audio | text |
+| grok-3 | ❌ | ✅ | text | text |
+| grok-3-mini | ❌ | ✅ | text | text |
+| jais-30b-chat | ❌ | ❌ | text | text |
+| mistral-medium-2505 | ❌ | ✅ | text, image | text |
+| mistral-small-2503 | ❌ | ✅ | text, image | text |
+| o1 | ✅ | ✅ | text, image | text |
+| o1-mini | ❌ | ❌ | text | text |
+| o1-preview | ❌ | ❌ | text | text |
+| o3 | ❌ | ✅ | text, image | text |
+| o3-mini | ✅ | ✅ | text | text |
+| o4-mini | ❌ | ✅ | text, image | text |
 
 ### AI21 Jamba 1.5 Large
 

--- a/tools/parse_models_json.py
+++ b/tools/parse_models_json.py
@@ -9,12 +9,6 @@ chat_models = []
 embedding_models = []
 
 
-def supports_streaming(name):
-    if name in ["o1", "o1-mini", "o1-preview", "o3-mini"]:
-        return False
-    return True
-
-
 def supports_schemas(name):
     if name in [
         "gpt-4o",
@@ -82,7 +76,6 @@ with open("models.json", "r", encoding="utf-8") as f:
             chat_models.append(
                 (
                     model["name"],
-                    supports_streaming(model["name"]),
                     supports_schemas(model["name"]),
                     requires_usage_stream_option(model["name"]),
                     supports_tools(model["name"]),
@@ -111,28 +104,23 @@ with open("models.fragment.md", "w", encoding="utf-8") as f:
 
     # Add chat models table
     f.write("### Chat Models\n\n")
-    f.write("| Model Name | Streaming | Schemas | Tools | Input Modalities | Output Modalities |\n")
-    f.write("|------------|-----------|---------|-------|------------------|-------------------|\n")
+    f.write("| Model Name | Schemas | Tools | Input Modalities | Output Modalities |\n")
+    f.write("|------------|---------|-------|------------------|-------------------|\n")
 
     for (
         model_name,
-        streaming,
         schemas,
         usage_stream,
         tools,
         input_modalities,
         output_modalities,
     ) in chat_models:
-        streaming_str = "✅" if streaming else "❌"
         schemas_str = "✅" if schemas else "❌"
         tools_str = "✅" if tools else "❌"
         input_str = ", ".join(input_modalities) if input_modalities else "text"
         output_str = ", ".join(output_modalities) if output_modalities else "text"
 
-        f.write(
-            f"| {model_name} | {streaming_str} | {schemas_str} |"
-            f" {tools_str} | {input_str} | {output_str} |\n"
-        )
+        f.write(f"| {model_name} | {schemas_str} | {tools_str} | {input_str} | {output_str} |\n")
 
     f.write("\n")
 


### PR DESCRIPTION
I think that this support got added when the api-version got bumped in [this PR](https://github.com/tonybaloney/llm-github-models/commit/0f7005758298a775ff996b76a5290f71c9927046#diff-5559ccdbf77b85168cf27986ae47c7a07faceed3bc9cf989137982da6f33f51a)

In any event, the models support streaming now:

```sh
$ models=("o1" "o1-mini" "o1-preview" "o3-mini")

$ for model in "${models[@]}"; do 
    echo $model;
    llm -m github/$model "what is your favorite cheese? No thinking, just the name";
done

o1
Cheddar
o1-mini
Cheddar!
o1-preview
Gouda.
o3-mini
Cheddar

$ for model in "${models[@]}"; do 
    echo $model;
    llm -m github/$model "what is your favorite cheese? No thinking, just the name" --async;
done

o1
Cheddar.
o1-mini
Cheddar
o1-preview
I don't have personal preferences or feelings, so I don't have a favorite cheese.
o3-mini
Cheddar

# I added a dummy error to non-streaming to prove that we weren't going in to that path
$ for model in "${models[@]}"; do 
    echo $model;
    llm -m github/$model "what is your favorite cheese? No thinking, just the name" --no-stream;
done

o1
Error: Tried to use non-streaming
o1-mini
Error: Tried to use non-streaming
o1-preview
Error: Tried to use non-streaming
o3-mini
Error: Tried to use non-streaming
```